### PR TITLE
Fix read_flights() after changes to ANAC data access

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,40 +2,41 @@ Type: Package
 Package: flightsbr
 Title: Download Flight and Airport Data from Brazil
 Version: 1.1.10999
-Authors@R: 
-    c(person(given="Rafael H. M.", family="Pereira", 
-             email="rafa.pereira.br@gmail.com", 
-             role=c("aut", "cre"), 
+Authors@R:
+    c(person(given="Rafael H. M.", family="Pereira",
+             email="rafa.pereira.br@gmail.com",
+             role=c("aut", "cre"),
              comment = c(ORCID = "0000-0003-2125-7465")),
       person(given = "Ipea - Institute for Applied Economic Research",
              role = c("cph", "fnd")))
 Description: Download flight and airport data from Brazil’s Civil Aviation Agency
-             (ANAC) <https://www.gov.br/anac/pt-br>. The data covers detailed 
-             information on aircraft, airports, and airport operations registered 
-             with ANAC. It also includes data on airfares, all international 
+             (ANAC) <https://www.gov.br/anac/pt-br>. The data covers detailed
+             information on aircraft, airports, and airport operations registered
+             with ANAC. It also includes data on airfares, all international
              flights to and from Brazil, and domestic flights  within the country.
 License: MIT + file LICENSE
 URL: https://github.com/ipeaGIT/flightsbr
 BugReports: https://github.com/ipeaGIT/flightsbr/issues
-Depends: 
+Depends:
     R (>= 2.10)
 Imports:
       archive,
       curl (>= 5.0.0),
       data.table (>= 1.14.0),
       fs,
+      httr2,
       lifecycle,
       parzer,
       pbapply,
       janitor,
       rvest
-Suggests: 
+Suggests:
     dplyr,
     ggplot2 (>= 3.3.1),
     rmarkdown (>= 2.6),
     knitr,
     testthat
-VignetteBuilder: 
+VignetteBuilder:
     knitr
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)

--- a/R/read_flights.R
+++ b/R/read_flights.R
@@ -9,9 +9,10 @@
 #' description of all variables included in the data is available at \url{https://www.gov.br/anac/pt-br/assuntos/regulados/empresas-aereas/Instrucoes-para-a-elaboracao-e-apresentacao-das-demonstracoes-contabeis/descricao-de-variaveis}.
 #'
 #' @param date Numeric. Date of the data in the format `yyyymm`. Defaults to
-#'             `202001`. To download the data for all months in a year, the user
-#'             can pass a 4-digit year input `yyyy`. The parameter also accepts
-#'             a vector of dates such as `c(202001, 202006, 202012)`.
+#'             the latest available month. To download the data for all months
+#'             in a year, the user can pass a 4-digit year input `yyyy`. The
+#'             parameter also accepts a vector of dates such as
+#'             `c(202001, 202006, 202012)`.
 #' @param type String. Whether the data set should be of the type `basica`
 #'             (flight stage, the default) or `combinada` (On flight origin and
 #'             destination - OFOD).
@@ -37,7 +38,7 @@ read_flights <- function(
   cache = TRUE
 ) {
   ### check inputs
-  type <- match.arg(type)
+  requested_type <- match.arg(type)
   if (!is.logical(showProgress)) {
     stop(paste0("Argument 'showProgress' must be either 'TRUE' or 'FALSE."))
   }
@@ -53,27 +54,30 @@ read_flights <- function(
     return(invisible(NULL))
   }
 
-  # subset files: only required type and dates
-  files <- files[type == ..type]
-
-  if(!is.null(date)) {
-    files <- files[date %in% ..date]
-  }
+  # subset files: only required type
+  files <- files[type == requested_type]
   all_dates <- files$date
-
 
   ### check date input
   if (is.null(date)) {
     date <- max(all_dates)
   }
-
   check_date(date = date, all_dates)
+
+  # expand years to months
+  if (all(nchar(date) == 4L)) {
+    date <- generate_all_months(date)
+  }
+
+  # subset files: only required dates
+  requested_dates <- date
+  files <- files[date %in% requested_dates]
 
   #### Download and read data
   dt_list <- download_flights_data(files$url, showProgress, select, cache)
 
   # check if download failed
-  if (is.null(dt)) {
+  if (is.null(dt_list)) {
     return(invisible(NULL))
   }
 

--- a/R/read_flights.R
+++ b/R/read_flights.R
@@ -53,9 +53,14 @@ read_flights <- function(
     return(invisible(NULL))
   }
 
+  # subset files: only required type and dates
   files <- files[type == ..type]
 
+  if(!is.null(date)) {
+    files <- files[date %in% ..date]
+  }
   all_dates <- files$date
+
 
   ### check date input
   if (is.null(date)) {
@@ -65,12 +70,7 @@ read_flights <- function(
   check_date(date = date, all_dates)
 
   #### Download and read data
-
-  # prepare url of online files
-  file_url <- get_flights_url(type = type, date = date)
-
-  # download and read data
-  dt_list <- download_flights_data(file_url, showProgress, select, cache)
+  dt_list <- download_flights_data(files$url, showProgress, select, cache)
 
   # check if download failed
   if (is.null(dt)) {

--- a/R/read_flights.R
+++ b/R/read_flights.R
@@ -29,46 +29,55 @@
 #'
 #' f2015 <- read_flights(date = 2015)
 #'}}
-read_flights <- function(date = NULL,
-                         type = 'basica',
-                         showProgress = TRUE,
-                         select = NULL,
-                         cache = TRUE
-                         ){
-
-### check inputs
-  if( ! type %in% c('basica', 'combinada') ){ stop(paste0("Argument 'type' must be either 'basica' or 'combinada'")) }
-  if( ! is.logical(showProgress) ){ stop(paste0("Argument 'showProgress' must be either 'TRUE' or 'FALSE.")) }
-  if( ! is.logical(cache) ){ stop(paste0("Argument 'cache' must be either 'TRUE' or 'FALSE.")) }
+read_flights <- function(
+  date = NULL,
+  type = c("basica", "combinada"),
+  showProgress = TRUE,
+  select = NULL,
+  cache = TRUE
+) {
+  ### check inputs
+  type <- match.arg(type)
+  if (!is.logical(showProgress)) {
+    stop(paste0("Argument 'showProgress' must be either 'TRUE' or 'FALSE."))
+  }
+  if (!is.logical(cache)) {
+    stop(paste0("Argument 'cache' must be either 'TRUE' or 'FALSE."))
+  }
   check_input_date_format(date)
 
-### check date input
-  # get all dates available
-  all_dates <- get_flight_dates_available()
+  ### get files available
+  files <- get_flights_files_available()
 
-  # check if download failed
-  if (is.null(all_dates)) { return(invisible(NULL)) }
+  if (is.null(files)) {
+    return(invisible(NULL))
+  }
 
-  # check dates
-  if (is.null(date)) { date <- max(all_dates) }
-  check_date(date=date, all_dates)
+  files <- files[type == ..type]
 
+  all_dates <- files$date
 
-#### Download and read data
+  ### check date input
+  if (is.null(date)) {
+    date <- max(all_dates)
+  }
+
+  check_date(date = date, all_dates)
+
+  #### Download and read data
 
   # prepare url of online files
-  file_url <- get_flights_url(type=type, date=date)
+  file_url <- get_flights_url(type = type, date = date)
 
   # download and read data
-  dt_list <- download_flights_data(file_url,
-                                   showProgress,
-                                   select,
-                                   cache)
+  dt_list <- download_flights_data(file_url, showProgress, select, cache)
 
   # check if download failed
-  if (is.null(dt)) { return(invisible(NULL)) }
+  if (is.null(dt)) {
+    return(invisible(NULL))
+  }
 
-#### prep data
+  #### prep data
 
   # row bind data tables
   dt <- data.table::rbindlist(dt_list, fill = TRUE)
@@ -86,4 +95,3 @@ read_flights <- function(date = NULL,
 
   return(dt)
 }
-

--- a/R/utils_flights.R
+++ b/R/utils_flights.R
@@ -35,6 +35,7 @@ get_flights_files_available <- function() { # nocov start
   h <- httr2::resp_body_html(resp)
 
   rows <- rvest::html_elements(h, "tbody tr")
+  rows <- rows[-1]
 
   files <- lapply(rows, function(row) {
 
@@ -63,13 +64,15 @@ get_flights_files_available <- function() { # nocov start
       as.numeric(paste0(year, sprintf("%02d", as.numeric(month))))
     )
 
-    data.table::data.table(
+    tbl <- data.table::data.table(
       # year = rep(year, 2L),
       # month = rep(month, 2L),
       date = rep(date, 2L),
       type = c("basica", "combinada"),
       url = c(basica_url, combinada_url)
     )
+
+    return(tbl)
   })
 
   files <- data.table::rbindlist(files, fill = TRUE)

--- a/R/utils_flights.R
+++ b/R/utils_flights.R
@@ -13,19 +13,21 @@ get_flights_files_available <- function() { # nocov start
     "envio-de-informacoes"
   )
 
-  req <- httr2::request(url) |>
-    httr2::req_user_agent(
-      "Mozilla/5.0 (compatible; flightsbr; +https://github.com/ipea/flightsbr)"
-    ) |>
-    httr2::req_headers(
-      Accept = paste0(
-        "text/html,application/xhtml+xml,application/xml;",
-        "q=0.9,*/*;q=0.8"
-      ),
-      `Accept-Language` = "pt-BR,pt;q=0.9,en;q=0.8"
-    ) |>
-    httr2::req_perform()
-  resp <- try(req, silent = TRUE)
+  resp <- try(
+    httr2::request(url) |>
+      httr2::req_user_agent(
+        "Mozilla/5.0 (compatible; flightsbr; +https://github.com/ipea/flightsbr)"
+      ) |>
+      httr2::req_headers(
+        Accept = paste0(
+          "text/html,application/xhtml+xml,application/xml;",
+          "q=0.9,*/*;q=0.8"
+        ),
+        `Accept-Language` = "pt-BR,pt;q=0.9,en;q=0.8"
+      ) |>
+      httr2::req_perform(),
+    silent = TRUE
+  )
 
   if (inherits(resp, "try-error")) {
     message("Problem connecting to ANAC data server. Please try it again.")
@@ -34,56 +36,88 @@ get_flights_files_available <- function() { # nocov start
 
   h <- httr2::resp_body_html(resp)
 
-  rows <- rvest::html_elements(h, "tbody tr")
-  rows <- rows[-1]
+  # rows <- rvest::html_elements(h, "tr")
+  tables <- rvest::html_elements(h, "table")
 
-  files <- lapply(rows, function(row) {
+  files <- lapply(tables, function(tbl) {
+    headers <- tbl |>
+      rvest::html_elements(xpath = "./thead/tr/th") |>
+      rvest::html_text2() |>
+      trimws() |>
+      janitor::make_clean_names()
 
-    cells <- row |>
-      rvest::html_elements("td")
+    required <- c("ano", "mes", "basica", "combinada")
 
-    if (length(cells) < 5L) {
+    if (!all(required %in% headers)) {
       return(NULL)
     }
 
-    year <- cells[[1]] |>
-      rvest::html_text2()
+    year_col <- match("ano", headers)
+    month_col <- match("mes", headers)
+    basica_col <- match("basica", headers)
+    combinada_col <- match("combinada", headers)
 
-    month <- cells[[2]] |>
-      rvest::html_text2()
+    rows <- tbl |>
+      rvest::html_elements(xpath = "./tbody/tr")
 
-    basica_url <- cells[[4]] |>
-      rvest::html_element("a") |>
-      rvest::html_attr("href")
+    out <- lapply(rows, function(row) {
+      cells <- row |>
+        rvest::html_elements(xpath = "./td")
 
-    combinada_url <- cells[[5]] |>
-      rvest::html_element("a") |>
-      rvest::html_attr("href")
+      if (
+        length(cells) <
+          max(
+            year_col,
+            month_col,
+            basica_col,
+            combinada_col
+          )
+      ) {
+        return(NULL)
+      }
 
-    date <- suppressWarnings(
-      as.numeric(paste0(year, sprintf("%02d", as.numeric(month))))
-    )
+      year <- cells[[year_col]] |>
+        rvest::html_text2() |>
+        as.integer()
 
-    tbl <- data.table::data.table(
-      # year = rep(year, 2L),
-      # month = rep(month, 2L),
-      date = rep(date, 2L),
-      type = c("basica", "combinada"),
-      url = c(basica_url, combinada_url)
-    )
+      month <- cells[[month_col]] |>
+        rvest::html_text2() |>
+        as.integer()
 
-    return(tbl)
+      if (is.na(year) || is.na(month)) {
+        return(NULL)
+      }
+
+      basica_url <- cells[[basica_col]] |>
+        rvest::html_element("a") |>
+        rvest::html_attr("href")
+
+      combinada_url <- cells[[combinada_col]] |>
+        rvest::html_element("a") |>
+        rvest::html_attr("href")
+
+      tbl_out <- data.table::data.table(
+        date = rep(year * 100L + month, 2L),
+        type = c("basica", "combinada"),
+        url = c(basica_url, combinada_url)
+      )
+
+      return(tbl_out)
+    })
+
+    return(data.table::rbindlist(out, fill = TRUE))
   })
 
   files <- data.table::rbindlist(files, fill = TRUE)
 
   files <- files[
     !is.na(date) &
-    !is.na(url) &
-    nzchar(url)
+      !is.na(url) &
+      nzchar(url)
   ]
 
   files <- unique(files)
+
   return(files)
 } # nocov end
 

--- a/R/utils_flightst.R
+++ b/R/utils_flightst.R
@@ -1,5 +1,97 @@
+
+# get_flights_files_available ----------------------------------------------------------------
+
+#' Retrieve flight files available from the ANAC website
+#'
+#' @return A data.table with columns `date`, `type`, and `url`.
+#' @keywords internal
+get_flights_files_available <- function() { # nocov start
+
+  url <- paste0(
+    "https://www.gov.br/anac/pt-br/assuntos/regulados/empresas-aereas/",
+    "Instrucoes-para-a-elaboracao-e-apresentacao-das-demonstracoes-contabeis/",
+    "envio-de-informacoes"
+  )
+
+  req <- httr2::request(url) |>
+    httr2::req_user_agent(
+      "Mozilla/5.0 (compatible; flightsbr; +https://github.com/ipea/flightsbr)"
+    ) |>
+    httr2::req_headers(
+      Accept = paste0(
+        "text/html,application/xhtml+xml,application/xml;",
+        "q=0.9,*/*;q=0.8"
+      ),
+      `Accept-Language` = "pt-BR,pt;q=0.9,en;q=0.8"
+    ) |>
+    httr2::req_perform()
+  resp <- try(req, silent = TRUE)
+
+  if (inherits(resp, "try-error")) {
+    message("Problem connecting to ANAC data server. Please try it again.")
+    return(invisible(NULL))
+  }
+
+  h <- httr2::resp_body_html(resp)
+
+  rows <- rvest::html_elements(h, "tbody tr")
+
+  files <- lapply(rows, function(row) {
+
+    cells <- row |>
+      rvest::html_elements("td")
+
+    if (length(cells) < 5L) {
+      return(NULL)
+    }
+
+    year <- cells[[1]] |>
+      rvest::html_text2()
+
+    month <- cells[[2]] |>
+      rvest::html_text2()
+
+    basica_url <- cells[[4]] |>
+      rvest::html_element("a") |>
+      rvest::html_attr("href")
+
+    combinada_url <- cells[[5]] |>
+      rvest::html_element("a") |>
+      rvest::html_attr("href")
+
+    date <- suppressWarnings(
+      as.numeric(paste0(year, sprintf("%02d", as.numeric(month))))
+    )
+
+    data.table::data.table(
+      # year = rep(year, 2L),
+      # month = rep(month, 2L),
+      date = rep(date, 2L),
+      type = c("basica", "combinada"),
+      url = c(basica_url, combinada_url)
+    )
+  })
+
+  files <- data.table::rbindlist(files, fill = TRUE)
+
+  files <- files[
+    !is.na(date) &
+    !is.na(url) &
+    nzchar(url)
+  ]
+
+  files <- unique(files)
+  return(files)
+} # nocov end
+
+
+# get_flight_dates_available -----------------------------------------------------------------
+
 #' Retrieve all dates available for flights data from ANAC website
 #'
+#' @param type String. Whether the data set should be of the type `basica`
+#'             (flight stage, the default) or `combinada` (On flight origin and
+#'             destination - OFOD).
 #' @return Numeric vector.
 #' @export
 #' @keywords internal
@@ -7,92 +99,35 @@
 #' # check dates
 #' a <- get_flight_dates_available()
 #'}}
-get_flight_dates_available <- function() { # nocov start
+get_flight_dates_available <- function(type = NULL) {
+  # nocov start
 
-  # read html table
-  url = 'https://www.gov.br/anac/pt-br/assuntos/regulados/empresas-aereas/Instrucoes-para-a-elaboracao-e-apresentacao-das-demonstracoes-contabeis/envio-de-informacoes'
-  h <- try(rvest::read_html(url), silent = TRUE)
+  if (!is.null(type)) {
+    requested_type <- match.arg(type, c("basica", "combinada"))
+  } else {
+    requested_type <- NULL
+  }
 
-  # check if internet connection worked
-  if (class(h)[1]=='try-error') {
-    message("Problem connecting to ANAC data server. Please try it again.")
+  files <- get_flights_files_available()
+
+  if (is.null(files)) {
     return(invisible(NULL))
   }
 
-  # filter elements of basica data
-  elements <- rvest::html_elements(h, "a")
-  basica_urls <- elements[ data.table::like(elements, '/basica') ]
-  basica_urls <- lapply(X=basica_urls, FUN=function(i){rvest::html_attr(i,"href")})
-
-  # get all dates available
-  all_dates <- substr(basica_urls, (nchar(basica_urls) + 1) -11, nchar(basica_urls)-4 )
-  all_dates <- gsub("[-]", "", all_dates)
-
-  # remove eventual letters
-  all_dates <- sub("a", "", all_dates, fixed = TRUE)
-  ## remove ALL eventual letters
-  # all_dates <- lapply(X = base::letters,
-  #                     FUN = function(x){
-  #                       all_datesf <- sub(x, "", all_dates, fixed = TRUE)
-  #                       return(all_datesf)}
-  #                     )
-  all_dates <- unique(all_dates)
-  all_dates <- as.numeric(all_dates)
-  return(all_dates)
-}  # nocov end
-
-
-
-
-#' Put together the url of flight data files
-#'
-#' @param type String. Whether the data set should be of the type `basica`
-#'             (flight stage, the default) or `combinada` (On flight origin and
-#'             destination - OFOD).
-#' @param date Numeric. Date of the data in the format `yyyymm`. Defaults to
-#'             `202001`. To download the data for all months in a year, the user
-#'             can pass a 4-digit year input `yyyy`. The parameter also accepts
-#'             a vector of dates such as `c(202001, 202006, 202012)`.
-#'
-#' @return A url string.
-#'
-#' @keywords internal
-#' @examples \dontrun{ if (interactive()) {
-#' # Generate urls
-#' a <- get_flights_url(type='basica', year=2000, month=11)
-#'}}
-get_flights_url <- function(type, date) { # nocov start
-
-  # old https://www.gov.br/anac/pt-br/assuntos/regulados/empresas-aereas/envio-de-informacoes/microdados/basica2021-01.zip
-  # old https://www.gov.br/anac/pt-br/assuntos/regulados/empresas-aereas/Instrucoes-para-a-elaboracao-e-apresentacao-das-demonstracoes-contabeis/microdados/
-  # new https://www.gov.br/anac/pt-br/assuntos/regulados/empresas-aereas/Instrucoes-para-a-elaboracao-e-apresentacao-das-demonstracoes-contabeis/microdados/basica2021-01.zip
-
-  # set root url
-  url_root <- 'https://www.gov.br/anac/pt-br/assuntos/regulados/empresas-aereas/Instrucoes-para-a-elaboracao-e-apresentacao-das-demonstracoes-contabeis/envio-de-informacoes'
-
-  # date with format yyyymm
-  if (all(nchar(date)==6)) {
-    y <- substring(date, 1, 4)
-    m <- substring(date, 5, 6)
-    url_spec <- paste0('/', type,'/', y, '/',type, y, '-', m, '.zip')
-    file_urls <- paste0(url_root, url_spec)
-    #  file_names <- basename(file_urls)
+  if (!is.null(requested_type)) {
+    dates <- files[
+      type == requested_type,
+      sort(unique(date))
+    ]
+  } else {
+    dates <- unique(files$date)
   }
 
-  # date with format yyyy
-  if (all(nchar(date)==4)) {
-    all_dates <- generate_all_months(date)
-    y <- substring(all_dates, 1, 4)
-    m <- substring(all_dates, 5, 6)
-    url_spec <- paste0('/', type,'/', y, '/',type, y, '-', m, '.zip')
-    file_urls <- paste0(url_root, url_spec)
-    #  file_names <- basename(file_urls)
-  }
-
-  return(file_urls)
+  return(dates)
 } # nocov end
 
 
+# download_flights_data ----------------------------------------------------------------------
 
 #' Download and read ANAC flight data
 #'
@@ -197,4 +232,3 @@ download_flights_data <- function(file_url = parent.frame()$file_url,
   return(dt)
 
 } # nocov end
-


### PR DESCRIPTION
Proposed changes:
- Use `httr2` to retrieve the ANAC data page.
- Retrieve file URLs directly from ANAC tables instead of constructing them from date and type
- Parse table columns by their headers to accommodate changes in the page structure.

The new function `get_flights_files_available()` returns a `data.table` with columns `date`, `type`, and `url`, whereas `get_flights_dates_available()` is now a simple wrapper around it for backward compatibility ---I suggest removing it from the pipeline entirely.

Furthermore, the result of `get_flights_files_available` (minus the URL column) could be a useful output for the users, like a metadata/catalog table.

Fixes #52